### PR TITLE
Feature: Calendar View and History Page Refactor

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -56,7 +56,8 @@ exports.generateEncouragement = onCall(async (request) => {
 
   try {
     const model = genAI.getGenerativeModel({model: "gemini-1.5-flash"});
-    const prompt = `Encourage someone who completed: ${completedActivity}.`;
+    const prompt = "Generate a single, short, encouraging sentence for " +
+      `someone who completed this activity: ${completedActivity}.`;
     const result = await model.generateContent(prompt);
     const encouragement = result.response.text();
     logger.info("Encouragement generated successfully",

--- a/lib/activity_calendar_page.dart
+++ b/lib/activity_calendar_page.dart
@@ -39,6 +39,37 @@ class _ActivityCalendarPageState extends State<ActivityCalendarPage> {
               focusedDay: DateTime.now(),
               availableCalendarFormats: const {CalendarFormat.month: 'Month'},
               calendarBuilders: CalendarBuilders(
+                todayBuilder: (context, day, focusedDay) {
+                  final isCompleted = events[DateTime.utc(day.year, day.month, day.day)] != null;
+                  if (isCompleted) {
+                    return Container(
+                      margin: const EdgeInsets.all(4.0),
+                      alignment: Alignment.center,
+                      decoration: BoxDecoration(
+                        color: Colors.green.shade300,
+                        shape: BoxShape.circle,
+                        border: Border.all(color: Colors.purple.shade300, width: 2.0),
+                      ),
+                      child: Text(
+                        '${day.day}',
+                        style: const TextStyle(color: Colors.white),
+                      ),
+                    );
+                  } else {
+                    return Container(
+                      margin: const EdgeInsets.all(4.0),
+                      alignment: Alignment.center,
+                      decoration: BoxDecoration(
+                        shape: BoxShape.circle,
+                        border: Border.all(color: Colors.purple.shade300, width: 2.0),
+                      ),
+                      child: Text(
+                        '${day.day}',
+                        style: TextStyle(color: Colors.purple.shade300),
+                      ),
+                    );
+                  }
+                },
                 defaultBuilder: (context, day, focusedDay) {
                   if (events[DateTime.utc(day.year, day.month, day.day)] != null) {
                     return Container(

--- a/lib/activity_calendar_page.dart
+++ b/lib/activity_calendar_page.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/material.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:table_calendar/table_calendar.dart';
+import 'firestore_service.dart';
+
+class ActivityCalendarPage extends StatefulWidget {
+  final User user;
+
+  const ActivityCalendarPage({Key? key, required this.user}) : super(key: key);
+
+  @override
+  State<ActivityCalendarPage> createState() => _ActivityCalendarPageState();
+}
+
+class _ActivityCalendarPageState extends State<ActivityCalendarPage> {
+  final FirestoreService _firestoreService = FirestoreService();
+  late Future<List<String>> _activitiesFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _activitiesFuture = _firestoreService.getAccomplishedActivities(widget.user.uid);
+  }
+
+  Future<void> _showActivityCalendar(String activityName) async {
+    final history = await _firestoreService.getActivityHistory(widget.user.uid, activityName);
+    final events = { for (var item in history) DateTime.utc(item.year, item.month, item.day) : 'Completed' };
+
+    await showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: Text(activityName),
+          content: SizedBox(
+            width: double.maxFinite,
+            child: TableCalendar(
+              firstDay: DateTime.utc(2020, 1, 1),
+              lastDay: DateTime.utc(2030, 12, 31),
+              focusedDay: DateTime.now(),
+              availableCalendarFormats: const {CalendarFormat.month: 'Month'},
+              calendarBuilders: CalendarBuilders(
+                defaultBuilder: (context, day, focusedDay) {
+                  if (events[DateTime.utc(day.year, day.month, day.day)] != null) {
+                    return Container(
+                      margin: const EdgeInsets.all(4.0),
+                      alignment: Alignment.center,
+                      decoration: BoxDecoration(
+                        color: Colors.green.shade300,
+                        shape: BoxShape.circle,
+                      ),
+                      child: Text(
+                        '${day.day}',
+                        style: const TextStyle(color: Colors.white),
+                      ),
+                    );
+                  }
+                  return null;
+                },
+              ),
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Close'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<List<String>>(
+        future: _activitiesFuture,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snapshot.hasError) {
+            return const Center(child: Text('Error loading activities.'));
+          }
+          if (!snapshot.hasData || snapshot.data!.isEmpty) {
+            return const Center(child: Text('No accomplished activities yet.'));
+          }
+
+          final activities = snapshot.data!;
+
+          return ListView.builder(
+            itemCount: activities.length,
+            itemBuilder: (context, index) {
+              final activity = activities[index];
+              return ListTile(
+                title: Text(activity),
+                onTap: () => _showActivityCalendar(activity),
+              );
+            },
+          );
+        },
+      );
+  }
+}

--- a/lib/history_page.dart
+++ b/lib/history_page.dart
@@ -87,8 +87,12 @@ class _HistoryPageState extends State<HistoryPage> {
               return ListView.builder(
                 itemCount: accomplishments.length,
                 itemBuilder: (context, index) {
-                  return ListTile(
-                    title: Text(accomplishments[index]),
+                  return Card(
+                    margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                    child: ListTile(
+                      leading: const Icon(Icons.check_circle, color: Colors.green),
+                      title: Text(accomplishments[index]),
+                    ),
                   );
                 },
               );

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -159,236 +159,253 @@ class _HomePageState extends State<HomePage> {
   }
 
   Widget build(BuildContext context) {
-    return SingleChildScrollView(
-      child: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            // Affirmation Card
-            Card(
-              elevation: 4,
-              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-              child: Padding(
-                padding: const EdgeInsets.all(16.0),
-                child: Column(
-                  children: [
-                    Text(
-                      _affirmation,
-                      style: Theme.of(context).textTheme.headlineSmall,
-                      textAlign: TextAlign.center,
-                    ),
-                    const SizedBox(height: 20),
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                      children: [
-                        ElevatedButton(
-                          onPressed: _generateNewAffirmationFromAI,
-                          child: const Text('New Affirmation'),
-                        ),
-                        IconButton(
-                          icon: const Icon(Icons.thumb_up_outlined),
-                          onPressed: () {
-                            _saveAffirmationFeedback(true);
-                          },
-                        ),
-                        IconButton(
-                          icon: const Icon(Icons.thumb_down_outlined),
-                          onPressed: () {
-                            _saveAffirmationFeedback(false);
-                            _cloudFunctionService.generateNewAffirmation(_affirmation).then((newAffirmation) {
-                              setState(() {
-                                _affirmation = newAffirmation;
-                              });
-                            });
-                          },
-                        ),
-                      ],
-                    ),
-                  ],
-                ),
+    final ColorScheme colorScheme = Theme.of(context).colorScheme.copyWith(
+      primary: Colors.deepPurple.shade300,
+      secondary: Colors.orange.shade300,
+      background: Colors.grey.shade100,
+    );
+
+    return Scaffold(
+      backgroundColor: colorScheme.background,
+      body: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 600),
+          child: SingleChildScrollView(
+            child: Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  // Affirmation Section
+                  _buildAffirmationSection(colorScheme),
+                  const SizedBox(height: 20),
+
+                  // Main Content Grid
+                  _buildMainGrid(colorScheme),
+                  const SizedBox(height: 20),
+
+                  // Daily Activities Section
+                  _buildDailyActivitiesSection(colorScheme),
+                ],
               ),
             ),
-            const SizedBox(height: 20),
-
-            // Grid for other cards
-            GridView.count(
-              crossAxisCount: 2,
-              shrinkWrap: true,
-              physics: const NeverScrollableScrollPhysics(),
-              crossAxisSpacing: 16,
-              mainAxisSpacing: 16,
-              children: [
-                // Reflection Timer Card
-                Card(
-                  elevation: 4,
-                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-                  child: Padding(
-                    padding: const EdgeInsets.all(16.0),
-                    child: Column(
-                      children: [
-                        Text(
-                          'Reflection Timer',
-                          style: Theme.of(context).textTheme.titleLarge,
-                        ),
-                        const SizedBox(height: 10),
-                        Row(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: [
-                            DropdownButton<double>(
-                              value: _timerDuration,
-                              items: [0.5, 1.0, 2.0, 5.0, 10.0, 20.0].map((double value) {
-                                return DropdownMenuItem<double>(
-                                  value: value,
-                                  child: Text('$value min'),
-                                );
-                              }).toList(),
-                              onChanged: (newValue) {
-                                setState(() {
-                                  _timerDuration = newValue!;
-                                  _remainingSeconds = (_timerDuration * 60).toInt();
-                                });
-                              },
-                            ),
-                            const SizedBox(width: 20),
-                            ElevatedButton(
-                              onPressed: _isTimerRunning ? _stopTimer : _startTimer,
-                              child: Text(_isTimerRunning ? 'Stop' : 'Start'),
-                            ),
-                          ],
-                        ),
-                        const SizedBox(height: 10),
-                        Text(
-                          _formatDuration(_remainingSeconds),
-                          style: Theme.of(context).textTheme.headlineMedium,
-                          textAlign: TextAlign.center,
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-
-                // Daily Reminder Card
-                /*
-                Card(
-                  elevation: 4,
-                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-                  child: Padding(
-                    padding: const EdgeInsets.all(16.0),
-                    child: Column(
-                      children: [
-                        Text(
-                          'Daily Reminder',
-                          style: Theme.of(context).textTheme.titleLarge,
-                        ),
-                        const SizedBox(height: 10),
-                        Row(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: [
-                            DropdownButton<int>(
-                              value: _selectedHour,
-                              items: List.generate(24, (index) => index).map((hour) {
-                                return DropdownMenuItem<int>(
-                                  value: hour,
-                                  child: Text(hour.toString().padLeft(2, '0')),
-                                );
-                              }).toList(),
-                              onChanged: (newValue) {
-                                setState(() {
-                                  _selectedHour = newValue!;
-                                });
-                              },
-                            ),
-                            const Text(':'),
-                            DropdownButton<int>(
-                              value: _selectedMinute,
-                              items: List.generate(60, (index) => index).map((minute) {
-                                return DropdownMenuItem<int>(
-                                  value: minute,
-                                  child: Text(minute.toString().padLeft(2, '0')),
-                                );
-                              }).toList(),
-                              onChanged: (newValue) {
-                                setState(() {
-                                  _selectedMinute = newValue!;
-                                });
-                              },
-                            ),
-                          ],
-                        ),
-                        const SizedBox(height: 10),
-                        ElevatedButton(
-                          onPressed: _scheduleDailyReminder,
-                          child: const Text('Set Reminder'),
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-                */
-                // TODO: Re-enable daily reminder functionality
-              ],
-            ),
-            const SizedBox(height: 20),
-
-            // Daily Activities Card
-            Card(
-              elevation: 4,
-              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-              child: Padding(
-                padding: const EdgeInsets.all(16.0),
-                child: Column(
-                  children: [
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: [
-                        Text(
-                          'Daily Activities',
-                          style: Theme.of(context).textTheme.titleLarge,
-                        ),
-                        ElevatedButton(
-                          onPressed: () async {
-                            final updatedActivities = await Navigator.push(
-                              context,
-                              MaterialPageRoute(
-                                builder: (context) => ManageActivitiesPage(dailyActivities: _dailyActivities),
-                              ),
-                            );
-                            if (updatedActivities != null) {
-                              setState(() {
-                                _dailyActivities = updatedActivities;
-                              });
-                              await _firestoreService.saveDailyActivities(widget.user.uid, _dailyActivities);
-                            }
-                          },
-                          child: const Text('Manage'),
-                        ),
-                      ],
-                    ),
-                    const SizedBox(height: 10),
-                    ..._dailyActivities.keys.map((activity) {
-                      return CheckboxListTile(
-                        title: Text(activity),
-                        value: _dailyActivities[activity],
-                        onChanged: (newValue) async {
-                          setState(() {
-                            _dailyActivities[activity] = newValue!;
-                          });
-                          await _firestoreService.saveDailyActivities(widget.user.uid, _dailyActivities);
-                          if (newValue == true) {
-                            await _firestoreService.addAccomplishment(widget.user.uid, activity);
-                            final encouragement = await _cloudFunctionService.generateEncouragement(activity);
-                            _showEncouragement(encouragement);
-                          }
-                        },
-                      );
-                    }).toList(),
-                  ],
-                ),
-              ),
-            ),
-          ],
+          ),
         ),
+      ),
+    );
+  }
+
+  Widget _buildAffirmationSection(ColorScheme colorScheme) {
+    return Container(
+      padding: const EdgeInsets.all(24.0),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.grey.withOpacity(0.2),
+            spreadRadius: 2,
+            blurRadius: 8,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      child: Column(
+        children: [
+          Text(
+            _affirmation,
+            style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+              color: Colors.black87,
+              fontWeight: FontWeight.w500,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 20),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: [
+              ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: colorScheme.primary,
+                  foregroundColor: Colors.white,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(30),
+                  ),
+                ),
+                onPressed: _generateNewAffirmationFromAI,
+                child: const Text('New Affirmation'),
+              ),
+              IconButton(
+                icon: const Icon(Icons.thumb_up_outlined),
+                color: Colors.green,
+                onPressed: () => _saveAffirmationFeedback(true),
+              ),
+              IconButton(
+                icon: const Icon(Icons.thumb_down_outlined),
+                color: Colors.red,
+                onPressed: () {
+                  _saveAffirmationFeedback(false);
+                  _cloudFunctionService.generateNewAffirmation(_affirmation).then((newAffirmation) {
+                    setState(() {
+                      _affirmation = newAffirmation;
+                    });
+                  });
+                },
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMainGrid(ColorScheme colorScheme) {
+    return _buildReflectionTimer(colorScheme);
+  }
+
+  Widget _buildReflectionTimer(ColorScheme colorScheme) {
+    return Container(
+      padding: const EdgeInsets.all(16.0),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.grey.withOpacity(0.2),
+            spreadRadius: 2,
+            blurRadius: 8,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(
+            'Reflection Timer',
+            style: Theme.of(context).textTheme.titleLarge?.copyWith(
+              fontWeight: FontWeight.bold,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 10),
+          Text(
+            _formatDuration(_remainingSeconds),
+            style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+              color: colorScheme.primary,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 10),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              DropdownButton<double>(
+                value: _timerDuration,
+                items: [0.5, 1.0, 2.0, 5.0, 10.0, 20.0].map((double value) {
+                  return DropdownMenuItem<double>(
+                    value: value,
+                    child: Text('$value min'),
+                  );
+                }).toList(),
+                onChanged: (newValue) {
+                  setState(() {
+                    _timerDuration = newValue!;
+                    _remainingSeconds = (_timerDuration * 60).toInt();
+                  });
+                },
+              ),
+              const SizedBox(width: 10),
+              ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: _isTimerRunning ? Colors.redAccent : colorScheme.primary,
+                  foregroundColor: Colors.white,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(30),
+                  ),
+                ),
+                onPressed: _isTimerRunning ? _stopTimer : _startTimer,
+                child: Text(_isTimerRunning ? 'Stop' : 'Start'),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDailyActivitiesSection(ColorScheme colorScheme) {
+    return Container(
+      padding: const EdgeInsets.all(16.0),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.grey.withOpacity(0.2),
+            spreadRadius: 2,
+            blurRadius: 8,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      child: Column(
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                'Daily Activities',
+                style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: colorScheme.secondary,
+                  foregroundColor: Colors.white,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(30),
+                  ),
+                ),
+                onPressed: () async {
+                  final updatedActivities = await Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => ManageActivitiesPage(dailyActivities: _dailyActivities),
+                    ),
+                  );
+                  if (updatedActivities != null) {
+                    setState(() {
+                      _dailyActivities = updatedActivities;
+                    });
+                    await _firestoreService.saveDailyActivities(widget.user.uid, _dailyActivities);
+                  }
+                },
+                child: const Text('Manage'),
+              ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          ..._dailyActivities.keys.map((activity) {
+            return CheckboxListTile(
+              title: Text(activity),
+              value: _dailyActivities[activity],
+              onChanged: (newValue) async {
+                setState(() {
+                  _dailyActivities[activity] = newValue!;
+                });
+                await _firestoreService.saveDailyActivities(widget.user.uid, _dailyActivities);
+                if (newValue == true) {
+                  await _firestoreService.addAccomplishment(widget.user.uid, activity);
+                  final encouragement = await _cloudFunctionService.generateEncouragement(activity);
+                  _showEncouragement(encouragement);
+                }
+              },
+              activeColor: colorScheme.primary,
+            );
+          }).toList(),
+        ],
       ),
     );
   }

--- a/lib/main_scaffold.dart
+++ b/lib/main_scaffold.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:reathm/history_page.dart';
 import 'package:reathm/home_page.dart';
 import 'auth_service.dart';
+import 'activity_calendar_page.dart';
 
 class MainScaffold extends StatefulWidget {
   final User user;
@@ -24,6 +25,7 @@ class _MainScaffoldState extends State<MainScaffold> {
     _pages = [
       HomePage(user: widget.user),
       HistoryPage(user: widget.user),
+      ActivityCalendarPage(user: widget.user),
     ];
   }
 
@@ -33,14 +35,25 @@ class _MainScaffoldState extends State<MainScaffold> {
     });
   }
 
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
+  AppBar _buildAppBar() {
+    String title;
+    switch (_selectedIndex) {
+      case 1:
+        title = 'History';
+        break;
+      case 2:
+        title = 'Activity Calendar';
+        break;
+      default:
+        title = 'Reathm';
+    }
+
+    if (_selectedIndex == 0) {
+      return AppBar(
         title: const Text('Reathm'),
         actions: [
           PopupMenuButton<String>(
-            offset: const Offset(0, 50), // Adjust offset to position menu below icon
+            offset: const Offset(0, 50),
             icon: CircleAvatar(
               backgroundImage: widget.user.photoURL != null
                   ? NetworkImage(widget.user.photoURL!)
@@ -63,7 +76,7 @@ class _MainScaffoldState extends State<MainScaffold> {
             },
             itemBuilder: (BuildContext context) => <PopupMenuEntry<String>>[
               PopupMenuItem<String>(
-                enabled: false, // Make this item non-selectable
+                enabled: false,
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
@@ -92,7 +105,18 @@ class _MainScaffoldState extends State<MainScaffold> {
             ],
           ),
         ],
-      ),
+      );
+    } else {
+      return AppBar(
+        title: Text(title),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: _buildAppBar(),
       body: _pages[_selectedIndex],
       bottomNavigationBar: BottomNavigationBar(
         items: const <BottomNavigationBarItem>[
@@ -103,6 +127,10 @@ class _MainScaffoldState extends State<MainScaffold> {
           BottomNavigationBarItem(
             icon: Icon(Icons.history),
             label: 'History',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.calendar_today),
+            label: 'Calendar',
           ),
         ],
         currentIndex: _selectedIndex,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -584,6 +584,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.28.0"
+  simple_gesture_detector:
+    dependency: transitive
+    description:
+      name: simple_gesture_detector
+      sha256: ba2cd5af24ff20a0b8d609cec3f40e5b0744d2a71804a2616ae086b9c19d19a3
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -629,6 +637,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  table_calendar:
+    dependency: "direct main"
+    description:
+      name: table_calendar
+      sha256: b2896b7c86adf3a4d9c911d860120fe3dbe03c85db43b22fd61f14ee78cdbb63
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.3"
   term_glyph:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   intl: ^0.19.0
   google_sign_in: 6.1.0
   package_info_plus: ^8.0.0
+  table_calendar: ^3.1.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This pull request introduces a new "Activity Calendar" page and a completely refactored "History" page, based on
  user feedback. It also includes several UI/UX improvements and bug fixes.

  Key Features:

   * Activity Calendar Page:
       * A new tab that displays a list of unique activities.
       * Tapping on an activity opens a calendar view showing the completion history for that activity.
       * The calendar has an improved design, with completed days marked with a green circle. The current day is marked
         with a purple rim, which combines with the green fill if an activity was completed today.

   * Refactored History Page:
       * The "History" page now shows a day-by-day view of completed activities.
       * Users can navigate back and forth between days to see their history.
       * The UI has been improved with a card-based layout and a checkmark icon for each activity.

  Other Improvements:

   * New Navigation: The main screen now has a bottom navigation bar with three tabs: "Home", "History", and "Calendar".
   * Context-Aware App Bar: The app bar now shows a generic title for the "History" and "Calendar" pages, while keeping
     the custom "Reathm" banner on the "Home" page.
   * Bug Fixes:
       * Fixed an issue with the encouragement toast message showing raw AI instructions.
       * Resolved several layout and styling bugs on the home page.
       * Fixed a bug that caused a double app bar to appear on the calendar page.
